### PR TITLE
feat: build container for pywb 2.8.3

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,21 @@
+version: 2
+updates:
+    - package-ecosystem: "docker"
+      directory: "/"
+      schedule:
+          interval: "weekly"
+      labels:
+          - "dependencies"
+      commit-message:
+          prefix: "build"
+          include: "scope"
+
+    - package-ecosystem: "github-actions"
+      directory: "/"
+      schedule:
+          interval: "weekly"
+      labels:
+          - "dependencies"
+      commit-message:
+          prefix: "build"
+          include: "scope"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,9 +12,6 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        version: [2.6.7, 2.6.8, 2.6.9, 2.7.2, 2.7.3]
     steps:
       - name: Extract metadata (tags, labels) for Docker
         id: meta
@@ -42,5 +39,3 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          build-args: |
-            PYWB_VERSION=${{ matrix.version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Release
 on:
   push:
     tags:
-      - v*
+      - "v[0-9]+.[0-9]+.[0-9]+.*"
 
 env:
   REGISTRY: ghcr.io

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,5 @@
-ARG PYWB_VERSION=2.7.3
+FROM docker.io/webrecorder/pywb:2.8.3 as pywb
 
-FROM docker.io/webrecorder/pywb:$PYWB_VERSION as pywb
-
-FROM docker.io/nginx:1.23-alpine
+FROM docker.io/nginx:1.25-alpine
 
 COPY --from=pywb /pywb/pywb/static /usr/share/nginx/html/static


### PR DESCRIPTION
This PR updates the pywb version to 2.8.3 and simplifies the configuration to rely on dependabot to update.